### PR TITLE
Proper line wrap for docstrings etc.

### DIFF
--- a/fireplaylib/client.py
+++ b/fireplaylib/client.py
@@ -3,6 +3,7 @@ import socket
 
 from errors import InvalidResponseException, ErrorCodes
 
+
 class MozClient(object):
     max_packet_length = 4096
 
@@ -15,9 +16,10 @@ class MozClient(object):
         self.actor = 'root'
 
     def _recv_n_bytes(self, n):
-        """ Convenience method for receiving exactly n bytes from
-self.sock (assuming it's open and connected).
-"""
+        """
+        Convenience method for receiving exactly n bytes from self.sock
+        (assuming it's open and connected).
+        """
         data = ''
         while len(data) < n:
             chunk = self.sock.recv(n - len(data))
@@ -27,10 +29,11 @@ self.sock (assuming it's open and connected).
         return data
 
     def receive(self):
-        """ Receive the next complete response from the server, and return
-it as a dict. Each response from the server is prepended by
-len(message) + ':'.
-"""
+        """
+        Receive the next complete response from the server, and return
+        it as a dict. Each response from the server is prepended by
+        len(message) + ':'.
+        """
         assert(self.sock)
         response = self.sock.recv(10)
         sep = response.find(':')
@@ -40,15 +43,15 @@ len(message) + ':'.
             response += self._recv_n_bytes(int(length) + 1 + len(length) - 10)
             return json.loads(response)
         else:
-            raise InvalidResponseException("Could not successfully complete " \
-                                           "transport of message to Gecko, "
-                                           "socket closed?",
-                                           status=ErrorCodes.INVALID_RESPONSE)
+            raise InvalidResponseException(
+                "Could not successfully complete transport of message to "
+                "Gecko, socket closed?", status=ErrorCodes.INVALID_RESPONSE)
 
     def connect(self, timeout=180.0):
-        """ Connect to the server and process the hello message we expect
-to receive in response.
-"""
+        """
+        Connect to the server and process the hello message we expect
+        to receive in response.
+        """
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.sock.settimeout(timeout)
         try:
@@ -63,8 +66,9 @@ to receive in response.
         self.applicationType = hello.get('applicationType')
 
     def send(self, msg):
-        """ Send a message on the socket, prepending it with len(msg) + ':'.
-"""
+        """
+        Send a message on the socket, prepending it with len(msg) + ':'.
+        """
         if not self.sock:
             self.connect()
         data = json.dumps(msg)
@@ -101,7 +105,8 @@ to receive in response.
         return self.receive()
 
     def close(self):
-        """ Close the socket.
-"""
+        """
+        Close the socket.
+        """
         self.sock.close()
         self.sock = None


### PR DESCRIPTION
docstrings are: always triple quotes (you did that right), and if they are multi-line, they are indented differently than you did. Here's the whole description: http://legacy.python.org/dev/peps/pep-0257/

If you need them later, you can postprocess `somefunction.__doc__` with `textwrap.dedent`.
